### PR TITLE
Fix upload-pages-artifact version in static.yml

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v4
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: './dist'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ My custom Static RSS feed updated daily with Github Actions
 # Thanks To:
 ```
 https://github.com/tanrax/RSSPAPER (Update JAR as needed in this directory)
+https://github.com/actions/upload-pages-artifact (Using version v3)
 ```
 
 # TODO:
 update favicon.ico + maybe dp cloudpages + add certain rss feeds to their own category to declutter homepage?
+Note: Updated actions/upload-pages-artifact to version v3 to resolve package version not found error.


### PR DESCRIPTION
Update the version of `actions/upload-pages-artifact` in the workflow file to resolve the package version not found error.

* **.github/workflows/static.yml**
  - Change the version of `actions/upload-pages-artifact` from `v4` to `v3`.

* **README.md**
  - Add a note in the "Thanks To" section about using version `v3` of `actions/upload-pages-artifact`.
  - Add a note in the "TODO" section about updating the version to resolve the package version not found error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Hackers-Den/pull/1?shareId=59ef0f17-fbe2-4bd1-89a3-480f4fe32f3d).